### PR TITLE
:wrench: Update to use `dynamic/decode` and require stdlib 0.50

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -6,8 +6,8 @@ repository = { type = "github", user = "gleam-community", repo = "colour" }
 gleam = ">= 0.33.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.34"
-gleam_json = ">= 1.0.1 and < 3.0.0"
+gleam_stdlib = ">= 0.50.0 and < 2.0.0"
+gleam_json = ">= 2.2.0 and < 3.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
+gleeunit = ">= 1.3.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_json", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB10B0E7BF44282FB25162F1A24C1A025F6B93E777CCF238C4017E4EEF2CDE97" },
-  { name = "gleam_stdlib", version = "0.42.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CF1C19DAB36C82EF6A8C60CF38884825641EBEA45E5495760D642C2ABB266192" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
+  { name = "gleam_stdlib", version = "0.53.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "53F3E1E56F692C20FA3E0A23650AC46592464E40D8EF3EC7F364FB328E73CDF5" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
-gleam_json = { version = ">= 1.0.1 and < 3.0.0" }
-gleam_stdlib = { version = "~> 0.34" }
-gleeunit = { version = "~> 1.0" }
+gleam_json = { version = ">= 2.2.0 and < 3.0.0" }
+gleam_stdlib = { version = ">= 0.50.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.3.0 and < 2.0.0" }

--- a/src/gleam_community/colour.gleam
+++ b/src/gleam_community/colour.gleam
@@ -108,7 +108,7 @@
 
 // IMPORTS --------------------------------------------------------------------
 
-import gleam/dynamic.{type DecodeError, type Dynamic}
+import gleam/dynamic/decode
 import gleam/float
 import gleam/int
 import gleam/json.{type Json}
@@ -933,28 +933,26 @@ fn encode_hsla(h: Float, s: Float, l: Float, a: Float) -> Json {
 ///     </a>
 /// </div>
 ///
-pub fn decoder(json: Dynamic) -> Result(Colour, List(DecodeError)) {
-  dynamic.any([rgba_decoder, hsla_decoder])(json)
+pub fn decoder() -> decode.Decoder(Colour) {
+  decode.one_of(rgba_decoder(), or: [hsla_decoder()])
 }
 
-fn rgba_decoder(json: Dynamic) -> Result(Colour, List(DecodeError)) {
-  dynamic.decode4(
-    Rgba,
-    dynamic.field("r", dynamic.float),
-    dynamic.field("g", dynamic.float),
-    dynamic.field("b", dynamic.float),
-    dynamic.field("a", dynamic.float),
-  )(json)
+fn rgba_decoder() -> decode.Decoder(Colour) {
+  use r <- decode.field("r", decode.float)
+  use g <- decode.field("g", decode.float)
+  use b <- decode.field("b", decode.float)
+  use a <- decode.field("a", decode.float)
+
+  decode.success(Rgba(r, g, b, a))
 }
 
-fn hsla_decoder(json: Dynamic) -> Result(Colour, List(DecodeError)) {
-  dynamic.decode4(
-    Hsla,
-    dynamic.field("h", dynamic.float),
-    dynamic.field("s", dynamic.float),
-    dynamic.field("l", dynamic.float),
-    dynamic.field("a", dynamic.float),
-  )(json)
+fn hsla_decoder() -> decode.Decoder(Colour) {
+  use h <- decode.field("h", decode.float)
+  use s <- decode.field("s", decode.float)
+  use l <- decode.field("l", decode.float)
+  use a <- decode.field("a", decode.float)
+
+  decode.success(Hsla(h, s, l, a))
 }
 
 // COLOURS ---------------------------------------------------------------------

--- a/test/colour.gleam
+++ b/test/colour.gleam
@@ -210,6 +210,6 @@ pub fn json_identiy_test() {
   c
   |> colour.encode
   |> json.to_string
-  |> json.decode(colour.decoder)
+  |> json.parse(colour.decoder())
   |> should.equal(Ok(c))
 }


### PR DESCRIPTION
This fixes deprecation warnings on stdlib 0.53.

May warrant a major version bump as the signature of `colour.decoder()` has changed.