### PR TITLE
fix: pad the results of to_string if needed

### DIFF
--- a/src/gleam_community/colour.gleam
+++ b/src/gleam_community/colour.gleam
@@ -761,8 +761,14 @@ pub fn to_css_rgba_string(colour: Colour) -> String {
 /// </div>
 ///
 pub fn to_rgba_hex_string(colour: Colour) -> String {
-  to_rgba_hex(colour)
-  |> int.to_base16()
+  let hex_string =
+    to_rgba_hex(colour)
+    |> int.to_base16()
+
+  case string.length(hex_string) {
+    8 -> hex_string
+    l -> string.repeat("0", 8 - l) <> hex_string
+  }
 }
 
 /// Returns an rgb hex formatted `String` created from the given `Colour`.
@@ -788,8 +794,14 @@ pub fn to_rgba_hex_string(colour: Colour) -> String {
 /// </div>
 ///
 pub fn to_rgb_hex_string(colour: Colour) -> String {
-  to_rgb_hex(colour)
-  |> int.to_base16()
+  let hex_string =
+    to_rgb_hex(colour)
+    |> int.to_base16()
+
+  case string.length(hex_string) {
+    6 -> hex_string
+    l -> string.repeat("0", 6 - l) <> hex_string
+  }
 }
 
 /// Returns an hex `Int` created from the given `Colour`.

--- a/test/colour.gleam
+++ b/test/colour.gleam
@@ -150,6 +150,20 @@ pub fn to_rgba_hex_string_test() {
   |> should.equal("FFAFF3FF")
 }
 
+pub fn pad_rgba_hex_string_test() {
+  let assert Ok(c) = colour.from_rgba(r: 0.0, g: 1.0, b: 0.0, a: 1.0)
+
+  c
+  |> colour.to_rgba_hex_string()
+  |> should.equal("00FF00FF")
+
+  let assert Ok(c) = colour.from_rgba(r: 0.0, g: 0.0, b: 0.0, a: 1.0)
+
+  c
+  |> colour.to_rgba_hex_string()
+  |> should.equal("000000FF")
+}
+
 pub fn to_rgb_hex_string_test() {
   let assert Ok(c) = colour.from_rgba(r: 1.0, g: 1.0, b: 1.0, a: 1.0)
 
@@ -166,6 +180,20 @@ pub fn to_rgb_hex_string_test() {
   colour.pink
   |> colour.to_rgb_hex_string()
   |> should.equal("FFAFF3")
+}
+
+pub fn pad_rgb_hex_string_test() {
+  let assert Ok(c) = colour.from_rgb(r: 0.0, g: 1.0, b: 0.0)
+
+  c
+  |> colour.to_rgb_hex_string()
+  |> should.equal("00FF00")
+
+  let assert Ok(c) = colour.from_rgb(r: 0.0, g: 0.0, b: 0.0)
+
+  c
+  |> colour.to_rgb_hex_string()
+  |> should.equal("000000")
 }
 
 pub fn to_rgba_hex_test() {


### PR DESCRIPTION
Closes #17 

I think it makes sense to pad the strings with leading "0"s when needed for comparability css, but if we wanted to add the leading "#" for users that should probably be a new function IMO